### PR TITLE
Chargestone ID Fix

### DIFF
--- a/common/src/main/java/com/thepokecraftmod/pokecraft/level/item/PokeCraftItems.java
+++ b/common/src/main/java/com/thepokecraftmod/pokecraft/level/item/PokeCraftItems.java
@@ -621,8 +621,8 @@ public class PokeCraftItems {
     public static final Item RUBY = register("ruby", new Item(GENERIC_PROPERTIES), PokeCraftCreativeTabs.NATURAL);
     public static final Item SAPPHIRE = register("sapphire", new Item(GENERIC_PROPERTIES), PokeCraftCreativeTabs.NATURAL);
     public static final Item CHARGESTONE = register("chargestone", new Item(GENERIC_PROPERTIES), PokeCraftCreativeTabs.NATURAL);
-    public static final Item RAW_Z_ORE = register("chargestone", new Item(GENERIC_PROPERTIES), PokeCraftCreativeTabs.NATURAL);
-    public static final Item Z_CRYSTAL = register("chargestone", new Item(GENERIC_PROPERTIES), PokeCraftCreativeTabs.NATURAL);
+    public static final Item RAW_Z_ORE = register("raw_z_ore", new Item(GENERIC_PROPERTIES), PokeCraftCreativeTabs.NATURAL);
+    public static final Item Z_CRYSTAL = register("z_crystal", new Item(GENERIC_PROPERTIES), PokeCraftCreativeTabs.NATURAL);
     public static final Item WISHING_CHIP = register("wishing_chip", new Item(GENERIC_PROPERTIES), PokeCraftCreativeTabs.NATURAL);
     public static final Item WISHING_PIECE = register("wishing_piece", new Item(GENERIC_PROPERTIES), PokeCraftCreativeTabs.NATURAL);
     public static final Item WISHING_STAR = register("wishing_star", new Item(SIXTEEN_PROPERTIES), PokeCraftCreativeTabs.NATURAL);


### PR DESCRIPTION
Same id were registered for RAW_Z_ORE and Z_CRYSTAL.